### PR TITLE
Proposal for update to documents

### DIFF
--- a/proposals/CHARTER.md
+++ b/proposals/CHARTER.md
@@ -60,9 +60,13 @@ Members:
 
 ### Election Procedure
 
-The current membership of the TWG vote on new members. Elections shall be held in a public manner, using the forum designated by the HF bylaws for formal discussion. All language for the election publication requires prior approval by the ED or other delegated authority. All additional publication on the part of the TWG for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly between 60 and 70 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
 
-If not enough candidates apply for the number of seats expiring, the CTO or other HF-delegated authority may fill these seats as needed using their discretion.
+
+The current membership of the TWG vote on new members. Vacancies on the TWG are advertised using the forum designated by the HF bylaws for formal discussion, with a clear deadline and plenty of notice. Interested candidates will be encouraged to self-nominate. All language for the election publication requires prior approval by the ED or other delegated authority. All additional publication on the part of the TWG for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly between 60 and 70 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
+
+If not enough candidates apply for the number of seats that are expiring or have been vacated, the ED or other HF-delegated authority may fill these seats as needed using their discretion.
+
+Both discussion about potential members and final vote tallies must be kept confidential by members of the TWG.
 
 ### Becoming a member
 

--- a/proposals/CHARTER.md
+++ b/proposals/CHARTER.md
@@ -60,7 +60,7 @@ Members:
 
 ### Election Procedure
 
-Elections shall be held in a public manner, using the forum designated by the HF bylaws for formal discussion. The ED or other HF-delegated authority shall approve all language for the election publication. All additional publication on the part of the TWG for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly exactly 60 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
+The current membership of the TWG vote on new members. Elections shall be held in a public manner, using the forum designated by the HF bylaws for formal discussion. All language for the election publication requires prior approval by the ED or other delegated authority. All additional publication on the part of the TWG for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly between 60 and 70 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
 
 If not enough candidates apply for the number of seats expiring, the CTO or other HF-delegated authority may fill these seats as needed using their discretion.
 
@@ -71,7 +71,7 @@ It is not required to be a part of the TWG in order to work on projects. In fact
 In order to become a member, one must apply at election time, and be elected to the TWG. With the exception of the first iteration of the TWG, all members are elected by means of the election process.
 
 
-## Voting Procedure
+## Proposal Voting Procedure
 
 Ranked voting is used, with the following criteria required for each status:
 

--- a/proposals/CHARTER.md
+++ b/proposals/CHARTER.md
@@ -1,19 +1,19 @@
-# Haskell Foundation Tech Track
+# Haskell Foundation Technical Working Group
 
 ---
 
-The Haskell Foundation Technical Track (HFTT) is a task force of the Haskell Foundation.
+The Haskell Foundation Technical Working Group (TWG) is a working group of the Haskell Foundation.
 
 ## Purpose
 
-The HF Technical Track is an experienced group of people with knowledge of the Haskell ecosystem, responsible for the strategic technical direction on behalf of the Haskell Foundation. HFTT members should be either individuals responsible for a specific part of the Haskell ecosystem, or contributors and committers to parts of it.
+The purpose of the TWG is to assess technical proposals on their merits, and to recommend whether the Haskell Foundation should devote resources to particular projects. The members of the TWG are an experienced group of people with knowledge of the Haskell ecosystem, responsible for the strategic technical direction on behalf of the Haskell Foundation. TWG members should be either individuals responsible for a specific part of the Haskell ecosystem, or contributors and committers to parts of it.
 
 
 ## Responsibilities
 
-HFTT Members are tasked with the following responsibilities:
+TWG Members are tasked with the following responsibilities:
 
-- Communicate with the community regarding technical the Haskell Foundation Technical Proposal (HFTP) process goings-on
+- Communicate with the community regarding the Haskell Foundation Technical Proposal (HFTP) process goings-on
 - Attend monthly HFTP meetings, weighing in pros and cons of every HFTP
 - Accept, postpone or reject each HFTP
 - Report regarding the status of assigned HFTPs when designated a shepherd
@@ -23,12 +23,12 @@ HFTT Members are tasked with the following responsibilities:
 
 None.
 
-The HFTT may make decisions regarding accepted technical projects. The Delegated Authority shall arrange budgetary or resource requests as needed, based on the outcome of decisions made by the HFTT, with the budget committee and Executive Director of the HF.
+The TWG may make decisions regarding accepted technical projects. The Delegated Authority shall arrange budgetary or resource requests as needed, based on the outcome of decisions made by the TWG, with the budget committee and Executive Director of the HF.
 
 
 ## Term
 
-The participation of least one person who is an HF Executive or delegated authority is required. General HFTT members serve for 3 years.
+The participation of least one person who is an HF Executive or delegated authority is required. General TWG members serve for 3 years.
 
 ## Membership
 
@@ -37,36 +37,38 @@ Delegated Authority:
 - David Thrane Christiansen ([@david-christiansen](https://github.com/david-christiansen))
 
 Members:
+| Name | GitHub Account | Joined |
+|------|----------------|--------|
+| Davean Scies | ([@davean](https://github.com/davean)) | ? |
+| Gershom Bazerman | ([@gbaz](https://github.com/gbaz)) | ? |
+| John Ericson | ([@Ericson2314](https://github.com/Ericson2314)) | ? |
+| Andrew Lelechenko | ([@bodigrim](https://github.com/Bodigrim)) | ? |
+| Hécate | ([@Kleidukos](https://github.com/Kleidukos)) | ? |
+| Koz Ross | ([@KozRoss](https://github.com/kozross)) | ? |
+| Evie Ciobanu | ([@eviefp](https://github.com/eviefp)) | ? |
+| Joachim Breitner | ([@nomeata](https://github.com/nomeata/)) | ? |
 
-- Chris Smith ([@cdsmith](https://github.com/cdsmith))
-- Davean Scies ([@davean](https://github.com/davean))
-- Gershom Bazerman ([@gbaz](https://github.com/gbaz))
-- John Ericson ([@Ericson2314](https://github.com/Ericson2314))
-- Andrew Lelechenko ([@bodigrim](https://github.com/Bodigrim))
-- Hécate ([@Kleidukos](https://github.com/Kleidukos))
-- Koz Ross ([@KozRoss](https://github.com/kozross))
-- Evie Ciobanu ([@eviefp](https://github.com/eviefp))
-- Joachim Breitner ([@nomeata](https://github.com/nomeata/))
 
 ## Membership Rules
 
 - Reporting must be accurate, consistent, and in good faith
-- Changes to HFTT membership require simple majority approval
-- 1 Delegated authority and 8 general members shall be required for a functioning HFTT
+- Changes to TWG membership require simple majority approval by the members of the TWG
+- 1 Delegated authority and 8 general members shall be required for a functioning TWG
 - No one may serve two terms consecutively, except for the CTO/delegated authority.
-- Elections *must* be held such that there is no period when the HFTT is not at full membership
+- Elections *must* be held such that there is no period when the TWG is not at full membership. In case of resignations, elections shall be held as soon as reasonably possible.
+- The Delegated Authority may, at their discretion, remove members who do not regularly carry out the responsibilities of working group members.
 
-## Election Procedure
+### Election Procedure
 
-Elections shall be held in a public manner, using the forum designated by the HF bylaws for formal discussion. The CTO or other HF-delegated authority shall approve all language for the election publication. All additional publication on the part of the HFTT for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly exactly 60 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
+Elections shall be held in a public manner, using the forum designated by the HF bylaws for formal discussion. The ED or other HF-delegated authority shall approve all language for the election publication. All additional publication on the part of the TWG for the purpose of socializing the election should link to the formal discussion. Elections should be announced publicly exactly 60 days before member terms expire, and submissions should cease to be accepted 14 days before member terms expire, with all membership decisions finalized and publicized 7 days before member terms expire. During this 7-day lame duck period, no votes may be made on proposals.
 
 If not enough candidates apply for the number of seats expiring, the CTO or other HF-delegated authority may fill these seats as needed using their discretion.
 
-## Becoming a member
+### Becoming a member
 
-It is not required to be a part of the HFTT in order to work on projects. In fact, it's quite the opposite: in order to find a list of projects on which to volunteer, one need only send a message (e.g. an email, slack DM, etc) to the leaders of individual projects. Likewise, individuals may freely contribute ideas and analysis of technical proposals by taking part in the HF Tech Proposal (HFTP) process commentary. However, the HFTT exists as the body empowered to ratify proposals and supervise projects to completion.
+It is not required to be a part of the TWG in order to work on projects. In fact, it's quite the opposite: in order to find a list of projects on which to volunteer, one need only send a message (e.g. an email, slack DM, etc) to the leaders of individual projects. Likewise, individuals may freely contribute ideas and analysis of technical proposals by taking part in the HF Tech Proposal (HFTP) process commentary. However, the TWG exists as the body empowered to ratify proposals and supervise projects to completion.
 
-In order to become a member, one must apply at election time, and be elected to the HFTT. With the exception of the first iteration of the HFTT, all members are elected by means of the election process.
+In order to become a member, one must apply at election time, and be elected to the TWG. With the exception of the first iteration of the TWG, all members are elected by means of the election process.
 
 
 ## Voting Procedure
@@ -83,24 +85,21 @@ Ranked voting is used, with the following criteria required for each status:
 
 ### Membership changes
 
-Membership changes require 66% majority for approval. All initial membership seats shall be appointed by the Delegated Authority, at their discretion.
-
+Membership changes require 66% majority for approval.
 
 ## Reporting
 
-HFTT members are expected to join monthly HFTP review meetings. If shepherding, project statuses should be reported at the bi-monthly HFTT standups.
+TWG members are expected to join monthly HFTP review meetings. If shepherding, project statuses should be reported to the TWG by email every two weeks.
 
 
 ## Documents
 
-The HFTT stores its working documents and deliverables in the public "Technical Agenda Task Force" folder in the Haskell
-Foundation Google Drive folder (see: https://drive.google.com/drive/u/0/folders/1aGuAbF-quAGqGYqlOEUXnPiFb-KarAa6). Additionall, all HFTP documents, including proposals, templates, charter, and proposal specification documents live in https://github.com/haskellfoundation/tech-proposals/.
+All HFTP documents, including proposals, templates, charter, and proposal specification documents, live in https://github.com/haskellfoundation/tech-proposals/.
 
 
-## HFTT Bylaws
+## TWG Bylaws
 
-Any change to this charter requires a 66% majority vote from the HFTT, with two exceptions:
+Changes to this charter can be made at the discretion of the director of the Haskell Foundation, after consulting with the members. Additionally:
 
-* The HFTT may change its method of document storage at will.
-* The HFTT may make changes to its membership according to the rules set
-  out in the *Membership Rules* section above.
+* The TWG may change its method of document storage at will.
+* The TWG may make changes to its membership according to the rules set out in the *Membership Rules* section above.

--- a/proposals/PROPOSALS.md
+++ b/proposals/PROPOSALS.md
@@ -1,10 +1,22 @@
-An HFTP (*Haskell Foundation Technical Proposal*) is a process for submitting a proposal for a technical initiative to that will be executed under the guidance of the Haskell Foundation (HF). This document describes how the community may propose, discuss, and implement technical initiatives to be carried out through the Haskell Foundation that will affect the Haskell ecosystem. Each HFTP goes through an iterative process in which it is discussed by the HF Technical Track (HFTT), the broader community, and any and all interested stakeholders. If a consensus is reached, the initiative is accepted and may then be executed by the Foundation (resources permitting). Only upon reaching a consensus are initiatives accepted and executed. Upon acceptance, an HFTP and its associated discussion are merged into this repository, and both serve as a historical document that details a specification and rationale for work detailed within the process.
+An HFTP (*Haskell Foundation Technical Proposal*) is a proposal for a technical initiative that will be executed under the guidance of the Haskell Foundation (HF). Each HFTP goes through an iterative process in which it is discussed by the HF Technical Working Group (TWG), the broader community, and any and all interested stakeholders. If the initiative is accepted, then it will be added to the HF's technical agenda and may then be executed by the Foundation, resources permitting. Upon acceptance, an HFTP and its associated discussion are merged into this repository, and both serve as a historical document that details a specification and rationale for work detailed within the process.
 
 The aim of the HFTP process is to apply the openness and collaboration that have shaped Haskell's documentation and implementation to a process of evolving the HF and the broader Haskell ecosystem. This document captures our guidelines, commitments and expectations regarding this process.
 
+## Submission process summary
+
+1. Submit a Pre-HFTP topic to [Discourse](https://discourse.haskell.org), soliciting informal feedback.
+2. If the feedback is favorable, fork the Haskell Foundation tech-proposals repository, [https://github.com/haskellfoundation/tech-proposals](https://github.com/haskellfoundation/tech-proposals).
+3. Create a new HFTP file in the `proposals/` directory. Use the [HFTP template](https://github.com/haskellfoundation/tech-proposals/blob/main/proposals/TEMPLATE.md)
+ * Make sure the new file's name follows the format: `YYYY-MM-dd-{title}.md`. Use the current date for `YYYY-MM-dd`.
+ * Use [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax) to write your HFTP.
+4. Commit your changes to your forked repository
+5. Create a new [pull request](https://github.com/haskellfoundation/tech-proposals/pull/new).
+6. Notify the TWG on Github using the team label `@haskellfoundation/tech-proposals`. Optionally, the address the `#tech-track` channel on the HF Slack instance or on Discourse (or both!).
+
+
 ## Why Write a Proposal?
 
-HFTPs are key to making the HF and its initiatives better for the good of everyone. If you decide to invest the time and effort of putting a proposal forward and see it through, your time and efforts will shape and improve the Haskell ecosystem, which means that your proposal may impact the life of a myriad of developers all over the world, including those on your own team. For many, this aspect alone can be quite worthwhile, however, the proposal process itself offers several key benefits to the broader community:
+HFTPs are key to making the HF and its initiatives better for the good of everyone. If you decide to invest the time and effort of putting a proposal forward and see it through, your time and efforts will shape and improve the Haskell ecosystem, which means that your proposal may impact the life of myriad developers all over the world, including those on your own team. For many, this aspect alone can be quite worthwhile; however, the proposal process itself offers several key benefits to the broader community:
 
 1. **Concretizing ideas:** as ideas for proposals are fleshed out, so too are the resource requirements, timelines, stakeholders, and available approaches. In this sense, a proposal allows us to fully concretize a proposal idea in terms of the work needed to complete the task.
 2. **Implementation guidance:**  the myriad of subject matter experts and stakeholders affected by a proposal can comment in a centralized place to form a consensus and guide the implementation strategy for a particular task.
@@ -26,11 +38,11 @@ Consider the following examples:
 - A contributor wants to write educational materials covering a yet-unwritten-about portion of Haskell, but requires an editor
 - An open source project requires funding for volunteers engaged in Summer of Code-type work on core tooling for Haskell
 
-In each of these cases, the author of the associated HFTP should detail the resource request for machines, an editor, or in terms of volunteer funding needed to meet their delivery goals. Throughout the HFTP process, these resource requests will be considered and weighed against the existing demand for HF resources. If accepted, these resource requests will be honored by the HF.
+In each of these cases, the author of the associated HFTP should detail the resource request for machines, an editor, or in terms of volunteer funding needed to meet their delivery goals. Throughout the HFTP process, these resource requests will be considered and weighed against the existing demand for HF resources. If accepted, these resource requests be honored by the HF to the extent possible.
 
 ### Proposal Size
 
-There is no size floor or ceiling for project submissions. Each HFTP will be weighed against the existing resource pool to decide whether a proposal is ready for acceptance. In particular, small quality of life proposals are as welcome as epic community-shifting proposals - we do not judge. However, this is why step 1 (informal discussion) is so important: often, it may be faster and easier to just make that Pull Request and find people who are free to do it with you! If, for some reason, the discovery and discussion phase does not catch these issues, it will be raised by HFTT members when appropriate. When a proposal, big or small, is inappropriate for the venue, we will be sure to make it known.
+There is no size floor or ceiling for project submissions. In particular, small quality of life proposals are as welcome as epic community-shifting proposals - we do not judge. However, this is why step 1 (informal discussion) is so important: often, it may be faster and easier to just make that Pull Request and find people who are free to do it with you! If, for some reason, the discovery and discussion phase does not catch these issues, it will be raised by TWG members when appropriate. When a proposal, big or small, is inappropriate for the venue, we will be sure to make it known.
 
 ## What's the process for submitting a HFTP?
 
@@ -43,38 +55,33 @@ There are four major steps in the HFTP process:
 
 ### Initial Discussion
 
-Before submitting a HFTP, it is required that you perform necessary preparations:
-
-- Discuss your idea on the [Haskell.org Discourse](https://discourse.haskell.org/). Currently, we suggest cross-posting on the Haskell Foundation Slack for higher volume commentary. Create a Discourse topic under the category "Haskell Foundation", that starts with "Pre-HFTP” and briefly describe what you would like to change and why you think it’s a good idea.
-
-- Proposing your ideas on the Discourse is not an optional step. For every change to the ecosystem, it is important to engage in due diligence with the community and relevant stakeholders. Use this step to promote your idea and gather early feedback on your Pre-HFTP proposal. It may happen that experts and community members may have tried something similar in the past and may offer valuable advice.
+Before submitting a HFTP, please write about your idea on the [Haskell.org Discourse](https://discourse.haskell.org/) and publicize the post in relevant venues. Create a Discourse topic under the category "Haskell Foundation", that starts with "Pre-HFTP” and briefly describe what you would like to change and why you think it’s a good idea. This helps discover prior art and related projects that are already underway. In some exceptional cases where prior art and existing projects are extremely unlikely, this requirement may be waived - please check in with the TWG if this is the case.
 
 
 ### Submission
 
-A HFTP is a Markdown document written in conformance with the [process template](https://github.com/haskellfoundation/tech-proposals/blob/main/proposals/TEMPLATE.md). When such changes significantly alter an existing library or tool, the author is invited to provide a proof of concept. Delivering a basic implementation can speed up the process dramatically. If your changes are big or somewhat controversial, don’t let people hypothesize about them and show results upfront. Additionally, it would be ideal if the author of the proposal reached out to any stakeholders (e.g. library authors, maintainers) affected by the proposal and bring them into the formal discussion at this point.
+A HFTP is a Markdown document written in conformance with the [process template](https://github.com/haskellfoundation/tech-proposals/blob/main/proposals/TEMPLATE.md). When such changes significantly alter an existing library or tool, the author is invited to provide a proof of concept. Delivering a basic implementation can speed up the process dramatically. If your changes are big or somewhat controversial, don’t let people hypothesize about them and show results upfront. Additionally, the author of the proposal should reach out to any stakeholders (e.g. library authors, maintainers) affected by the proposal and bring them into the formal discussion at this point.
 
-A HFTP is submitted as a pull request against [the official Haskell tech proposal
-repo](https://github.com/haskellfoundation/tech-proposals). Within a week of receiving the pull request, members of the HFTT will acknowledge your submission, validate that it conforms to the proposal template guidelines (see: [TEMPLATE.md](TEMPLATE.md)) and provide feedback to improve the overall quality of the document (if necessary). When the document conforms to the template guidelines, it is ready for formal evaluation by the HFTT members, as well as the broader community.
+A HFTP is submitted as a pull request against [the official Haskell tech proposal repository](https://github.com/haskellfoundation/tech-proposals). Within a week of receiving the pull request, members of the TWG will acknowledge your submission, validate that it conforms to the proposal template guidelines (see: [TEMPLATE.md](TEMPLATE.md)) and provide feedback to improve the overall quality of the document (if necessary). When the document conforms to the template guidelines, it is ready for formal evaluation by the TWG members, as well as the broader community.
 
-### Formal Review (up to 5 iterations)
+### Formal Review
 
-While the majority of general technical commentary and feedback will occur on the proposal pull request and its associated issue, it's hard to tell when a particular proposal is finalized. This what we call "Formal Review".  The entire community is strongly encouraged to comment on, and help improve, a proposal. Ultimately, however, the Foundation needs a mechanism to make a decision, to accept, reject, or push back a proposal. This process is called "Formal Review", and is carried out by the HFTT working group.
+While the majority of general technical commentary and feedback will occur on the proposal pull request and its associated issue, it's hard to tell when a particular proposal is finalized. This what we call "Formal Review".  The entire community is strongly encouraged to comment on, and help improve, a proposal. Ultimately, however, the Foundation needs a mechanism to make a decision, to accept, reject, or push back a proposal. This process is called "Formal Review", and is carried out by the TWG working group.
 
 #### Formal Review
 
-Formal Review of a proposal is done in iterations. These iterations take place in the HFTT meetings and are usually monthly. However, they can last longer, in which case the author has more time to implement all the required changes.
+Formal Review of a proposal is done in iterations. These iterations take place in the TWG meetings and are usually monthly. However, they can last longer, in which case the author has more time to implement all the required changes.
 
-The maximum number of iterations is five. At the fifth iteration, the HFTT can only vote to Accept, Postpone, or Reject.
+The maximum number of iterations is five. At the fifth iteration, the TWG can only vote to Accept, Postpone, or Reject.
 
-The HFTT decides the duration of the next iteration depending upon the feedback and complexity of the HFTP. Consequently, authors have more time to prepare all the changes. If they finish their revision before the scheduled iteration, an HFTT member will reschedule it for the next available meeting.
+The TWG decides the duration of the next iteration depending upon the feedback and complexity of the HFTP. Consequently, authors have more time to prepare all the changes. If they finish their revision before the scheduled iteration, an TWG member will reschedule it for the next available meeting.
 
-During every iteration, the HFTT reviews the changes (updated design document, progress with the implementation, etc) to the proposal. Based on the feedback, the HFTP is either:
+During every iteration, the TWG reviews the changes (updated design document, progress with the implementation, etc) to the proposal. Based on the feedback, the HFTP is either:
 
-1. **Accepted**, in which case the HFTT has accepted the proposal, and it will be merged by the HFTT members.
+1. **Accepted**, in which case the TWG has accepted the proposal, and it will be merged by the TWG members.
 2. **Rejected**, in which case the HFTP is closed and no longer evaluated in the future.
-3. **Postponed**, in which case the HFTT sets aside the HFTP under some conditions. When those conditions are met, the HFTP can be resubmitted.
-4. **Under revision**, in which case the author needs to continue the formal evaluation and address all the HFTT feedback. Thus, the follow-up discussion is scheduled for the next iteration.
+3. **Postponed**, in which case the TWG sets aside the HFTP under some conditions. When those conditions are met, the HFTP can be resubmitted.
+4. **Under revision**, in which case the author needs to continue the formal evaluation and address all the TWG feedback. Thus, the follow-up discussion is scheduled for the next iteration.
 5. **Dormant**,  in which case no changes have been made to a HFTP in two iterations, it’s marked as dormant and both the PR and issue are closed. Dormant HFTPs can be reopened by any person, be it the same or different authors, at which point it will start from the formal evaluation phase.
 
 #### Involving Stakeholders
@@ -83,59 +90,47 @@ At this point where a proposal is being reviewed, if there are relevant stakehol
 
 #### Updating Proposal Statuses
 
-If the author of a particular proposal wants to update the status of their proposal, they should comment on the issue and alert the HFTT using the Github team tag `haskellfoundation/tech-proposals` with a note regarding what status they would like to update the proposal to. It is good to be redundant and raise the question in our other fora as well: Slack and Discourse. However, Github is required.
+If the author of a particular proposal wants to update the status of their proposal, they should comment on the issue and alert the TWG using the GitHub team tag `@haskellfoundation/tech-proposals` with a note regarding what status they would like to update the proposal to. It is good to be redundant and raise the question in our other fora as well: Slack and Discourse. However, Github is required.
 
 ### Acceptance
 
-Upon acceptance, an HFTP is merged into the repository by an HFTT member, and the HFTP is assigned a shepherd from the HFTT. A shepherd is chosen at random, and will serve as a liason for the project, guiding its progress. Shepherds are required to report dutifully and accurately on the progress at the bi-weekly HFTT standup meetings. Project leaders are welcome to arrange alternative reporting schema (e.g. as their schedules allow, or if time off is required) upon request, as long as reports are given on a consistent basis.
+Upon acceptance, an HFTP is merged into the repository by an TWG member, and the HFTP is assigned a shepherd from the TWG who will serve as a liason for the project, guiding its progress. Shepherds are required to report dutifully and accurately on the progress to the TWG. Project leaders are welcome to arrange alternative reporting schema (e.g. as their schedules allow, or if time off is required) upon request, as long as reports are given on a consistent basis.
 
-## The Role of the HFTT
+## The Role of the TWG
 
-Authors are responsible for building consensus within the community and documenting dissenting opinions before the HFTP is officially discussed by the HFTT. Their goal is to convince the HFTT that their proposal is useful and addresses pertinent problems in the Haskell ecosystem as well as interactions with already existing features. Authors can change over the life-cycle of the HFTP. For a formal charter, as well as a list of current HFTT members, please see [CHARTER.md](CHARTER.md).
+Authors are responsible for building consensus within the community and documenting dissenting opinions before the HFTP is officially discussed by the TWG. Their goal is to convince the TWG that their proposal is useful and addresses pertinent problems in the Haskell ecosystem as well as interactions with already existing features. Authors can change over the life-cycle of the HFTP. For a formal charter, as well as a list of current TWG members, please see [CHARTER.md](CHARTER.md).
 
 ### Voting
 
-When a HFTP is scheduled at an HFTT meeting (i.e. it is in 'Under Review'), it can be held to a vote for one of the following outcomes (in case it makes a difference: the HFTP will be marked according to the first on this list to have a majority) using a ranked voting method described in [CHARTER.md](CHARTER.md).
+When a HFTP is scheduled at an TWG meeting (i.e. it is in 'Under Review'), it can be held to a vote for one of the following outcomes (in case it makes a difference: the HFTP will be marked according to the first on this list to have a majority) using a ranked voting method described in [CHARTER.md](CHARTER.md).
 
-- Accepted (needs 66% of the HFTT to vote in favor, and the HFTP must specify a proposal lead, e.g. an implementor or project director, from the HFTT who will represent the work done on the project.)
-- Dormant (needs a simple majority, an HFTT member that voted in favor will close the issue and PR and mark it as Dormant)
-- Postponed (needs a simple majority, an HFTT member that voted to postpone will close the issue and PR, and write clear conditions for reopening)
-- Revision needed (needs a simple majority. This can only be the outcome of the vote four times, for a total of five rounds. An HFTT member will write up what revisions are needed.)
-- Rejected (needs 66% of the HFTT to vote in favor)
+- Accepted (needs 66% of the TWG to vote in favor, and the HFTP must specify a proposal lead, e.g. an implementor or project director, from the TWG who will represent the work done on the project.)
+- Dormant (needs a simple majority, an TWG member that voted in favor will close the issue and PR and mark it as Dormant)
+- Postponed (needs a simple majority, an TWG member that voted to postpone will close the issue and PR, and write clear conditions for reopening)
+- Revision needed (needs a simple majority. This can only be the outcome of the vote four times, for a total of five rounds. An TWG member will write up what revisions are needed.)
+- Rejected (needs 66% of the TWG to vote in favor)
 
 ### Guests
 
 Experts in some fields may be invited to specific meetings as guests when discussing related HFTPs. Their input would be important to discuss the current state of the proposal, both its design and implementation.
 
-### Joining the HFTT
+### Joining the TWG
 
-If you would like to join the HFTT or would like to know how members are elected, please refer to [CHARTER.md](CHARTER.md).
+If you would like to join the TWG or would like to know how members are elected, please refer to [CHARTER.md](CHARTER.md).
 
 ## Proposal states
 
-The state of a proposal changes over time depending on the phase of the process and the decisions taken by the HFTT. A given proposal can be in one of several states:
+The state of a proposal changes over time depending on the phase of the process and the decisions taken by the TWG. A given proposal can be in one of several states:
 
 0. **Discussion:** The proposal is being discussed informally on discourse. In this phase the proposal only exists informally, no pull request exists yet.
 1. **Submitted:** A pull request has been opened against the proposals repo.
 2. **Validated:** The submitted proposal has been validated for conformity to the [proposal template](TEMPLATE.md), and made all necessary changes to the proposal name and its location in the repo.
 3. **Under review:** The proposal will be under review until the next available Tech Track meeting takes place.
-4. **Under revision:** Authors are addressing the issues pinpointed throughout the discussion and feedback process from the community and/or the HFTT.
-5. **Dormant:** When a HFTP has been under revision for more than two iterations (that is, no progress has been made since the last review), it’s considered dormant, in which case any related activity will be paralyzed and the HFTT will not allocate more resources to it.
+4. **Under revision:** Authors are addressing the issues pinpointed throughout the discussion and feedback process from the community and/or the TWG.
+5. **Dormant:** When a HFTP has been under revision for more than two iterations (that is, no progress has been made since the last review), it’s considered dormant, in which case any related activity will be paralyzed and the TWG will not allocate more resources to it.
 6. **Postponed:** The HFTP has been postponed under some concrete conditions. When these are met, the HFTP can be resubmitted.
 7. **Rejected:** The HFTP has been rejected with a clear and full explanation.
 8. **Merged:** The HFTP has been accepted and has been merged into the repo.
 
 When a proposal has movede Haskell Foundation. Members are tasked with from one state to another, it will be appropriately labeled using the Github label system. The labels will be as they are above.
 
-## How do I submit? ##
-
-The process to submit is simple:
-
-* Submit a Pre-HFTP topic to the HF Discourse, soliciting informal feedback.
-* If the feedback is favorable, fork the Haskell Foundation tech-proposals repository, [https://github.com/haskellfoundation/tech-proposals](https://github.com/haskellfoundation/tech-proposals).
-* Create a new HFTP file in the `HFTPs/` directory. Use the [HFTP template](https://github.com/haskellfoundation/tech-proposals/blob/main/TEMPLATE.md)
- * Make sure the new file follows the format: `YYYY-MM-dd-{title}.md`. Use the current date for `YYYY-MM-dd`.
- * Use the [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax) to write your HFTP.
-* Commit your changes to your forked repository
-* Create a new [pull request](https://github.com/haskellfoundation/tech-proposals/pull/new).
-* Notify the HFTT on Github using the team label `@haskellfoundation/tech-proposals`. Optionally, the address the HFTT Slack instance or on Discourse (or both!).

--- a/proposals/PROPOSALS.md
+++ b/proposals/PROPOSALS.md
@@ -118,19 +118,4 @@ Experts in some fields may be invited to specific meetings as guests when discus
 
 If you would like to join the TWG or would like to know how members are elected, please refer to [CHARTER.md](CHARTER.md).
 
-## Proposal states
-
-The state of a proposal changes over time depending on the phase of the process and the decisions taken by the TWG. A given proposal can be in one of several states:
-
-0. **Discussion:** The proposal is being discussed informally on discourse. In this phase the proposal only exists informally, no pull request exists yet.
-1. **Submitted:** A pull request has been opened against the proposals repo.
-2. **Validated:** The submitted proposal has been validated for conformity to the [proposal template](TEMPLATE.md), and made all necessary changes to the proposal name and its location in the repo.
-3. **Under review:** The proposal will be under review until the next available Tech Track meeting takes place.
-4. **Under revision:** Authors are addressing the issues pinpointed throughout the discussion and feedback process from the community and/or the TWG.
-5. **Dormant:** When a HFTP has been under revision for more than two iterations (that is, no progress has been made since the last review), it’s considered dormant, in which case any related activity will be paralyzed and the TWG will not allocate more resources to it.
-6. **Postponed:** The HFTP has been postponed under some concrete conditions. When these are met, the HFTP can be resubmitted.
-7. **Rejected:** The HFTP has been rejected with a clear and full explanation.
-8. **Merged:** The HFTP has been accepted and has been merged into the repo.
-
-When a proposal has movede Haskell Foundation. Members are tasked with from one state to another, it will be appropriately labeled using the Github label system. The labels will be as they are above.
 

--- a/proposals/PROPOSALS.md
+++ b/proposals/PROPOSALS.md
@@ -1,6 +1,13 @@
-An HFTP (*Haskell Foundation Technical Proposal*) is a proposal for a technical initiative that will be executed under the guidance of the Haskell Foundation (HF). Each HFTP goes through an iterative process in which it is discussed by the HF Technical Working Group (TWG), the broader community, and any and all interested stakeholders. If the initiative is accepted, then it will be added to the HF's technical agenda and may then be executed by the Foundation, resources permitting. Upon acceptance, an HFTP and its associated discussion are merged into this repository, and both serve as a historical document that details a specification and rationale for work detailed within the process.
+An HFTP (*Haskell Foundation Technical Proposal*) is a proposal for a technical initiative that will be executed under the guidance of the Haskell Foundation (HF). Each HFTP goes through an iterative process in which it is discussed by the HF Technical Working Group (TWG), the broader community, and any and all interested stakeholders. As part of this process, resources are identified that could ease or make possible the implementation of the proposal.
 
 The aim of the HFTP process is to apply the openness and collaboration that have shaped Haskell's documentation and implementation to a process of evolving the HF and the broader Haskell ecosystem. This document captures our guidelines, commitments and expectations regarding this process.
+
+## Acceptance
+
+Upon acceptance, an HFTP and its associated discussion are merged into this repository, and both serve as a historical document that details a specification and rationale for work detailed within the process. Acceptance of a proposal does not constitute a firm commitment by the Haskell Foundation to execute on the proposal, or to provide the necessary or helpful resources that were identified in the proposal. Fundamentally, acceptance indicates that the TWG believes that the Haskell ecosystem would be better off if the proposal were implemented, and that it is sufficiently well-considered.
+
+That said, the Haskell Foundation is keenly interested in making the Haskell ecosystem better off. Within the constraints of the Foundation's resources and strategic plans, accepted proposals will be considered as good candidates for tasks to be executed on.
+
 
 ## Submission process summary
 


### PR DESCRIPTION
As discussed via email, I'd like to update a few things here and am interested in knowing what you think.

Here's a summary of the changes:
 * Rename the group to the Technical Working Group (I'd like to call all non-board groups "working groups" rather than a mix of "task force", "committee", "track", etc)
 * Remove references to the biweekly standups that don't actually happen
 * Clarify that the Pre-HFTP step is intended to do things like discover prior art, so it doesn't feel like bureaucratic make-work
 * Put the proposal process summary first,  to make the document less overwhelming
 * Add a provision in the charter that members who disappear can be replaced
 * Add dates to the charter so that we can track the three-year terms. I don't know those dates - **please comment here with yours!**
 * Remove the specification that shepherds are assigned at random, and simply stating that they're assigned (so we can e.g. take people's life situations and workloads into account)
 * Clarifications in the charter related to the two kinds of voting (membership and proposals)

Given that our problem is more lack of proposals than too many, we can also consider simplifying the formality of the proposal process. I'll save that for another round.