### PR TITLE
RFC: Reinvigorating the Haskell Symposium

### DIFF
--- a/proposals/0000-haskell-symposium-changes.md
+++ b/proposals/0000-haskell-symposium-changes.md
@@ -24,28 +24,18 @@ Talk proposals will not be distributed to attendees, but authors of talk proposa
 
 ## Proposal 2: JFP Submission of Accepted Papers
 
-The steering committee proposes to cease publishing the proceedings of the Haskell Symposium as an archival ACM publication.   Instead, **authors of accepted research papers and functional pearls will have the option of submitting their papers to an expedited review process for inclusion in the Journal of Functional Programming**. This provides a better-regarded publication venue for work presented at the Haskell Symposium, encouraging submission of high quality work to the Symposium.
+The steering committee proposes that authors of accepted papers may pursue publication in the Journal of Functional Programming, with an expedited process, instead of in the proceedings of the Haskell Symposium.  This provides a better-ranked publication venue for work presented at the Haskell Symposium, encouraging presentation of high quality work at the Symposium.
 
 ### For authors
 
-Under this proposal, authors will still submit papers to the Haskell Symposium, and receive reviews from the PC, on the usual schedule.    
+Under this proposal, authors will still submit papers to the Haskell Symposium, and receive reviews from the PC, on the usual schedule.  At the time of submission, authors may indicate that they would prefer their papers be considered for JFP, rather than included the proceedings of the Haskell Symposium.  Authors of accepted papers may change this decision on the basis of the reviews.
 
-Authors of accepted papers will present their papers at the Symposium.  
+Authors of accepted papers will present their papers at the Symposium, whether or not they are intended for JFP.  Authors of papers intended for JFP may also provide links to materials to be included in the program.
 
-JFP will accept the HS reviews as the first round of reviewing for JFP, provided the reviews meet the standards of the journal.  Authors of accepted papers will then be given the option to revise their papers for submission to the Journal of Functional Programming.  To assure that these appear in a timely fashion, the deadline for revision will likely be around the time of the Symposium itself.  Revised paper will be reviewed by JFP, most likely by the original reviewers.
+JFP will accept the HS reviews as the first round of reviewing for JFP, provided the reviews meet the standards of the journal.  Authors of accepted papers will then be given the option to revise their papers for submission to JFP.  To assure that these appear in a timely fashion, and to give authors the chance to include feedback from the Symposium, the deadline for revision will shorty after the Symposium itself.  Revised papers will be reviewed by JFP, most likely by the original reviewers.
 
 The final decision of the JFP editors is, of course, independent of the decision of the Haskell Symposium PC.
 
 ### For PC members
 
-Under this proposal, reviews of (accepted) papers should meet JFP's review standards.  Haskell Symposium reviewers should also be prepared to review paper revisions for JFP.
-
-### For the community
-
-A consequence of moving away from an archival proceedings is that ACM SIGPLAN may ask us to change the title of the meeting to something more like "Haskell Workshop", to line up with other language workshops held around ICFP.
-
-## Stakeholders
-
-The primary stakeholders are future authors and participants in the Haskell Symposium.    
-
-In particular, we invite feedback on whether the JFP submission process would make authors more (or less) likely to consider the Haskell Symposium as a venue for presenting work in the future.
+Under this proposal, reviews of (accepted) papers should meet JFP's review standards.  Haskell Symposium reviewers should also be prepared to review paper revisions for JFP.

--- a/proposals/0000-haskell-symposium-changes.md
+++ b/proposals/0000-haskell-symposium-changes.md
@@ -32,7 +32,7 @@ Under this proposal, authors will still submit papers to the Haskell Symposium, 
 
 Authors of accepted papers will present their papers at the Symposium, whether or not they are intended for JFP.  Authors of papers intended for JFP may also provide links to materials to be included in the program.
 
-JFP will accept the HS reviews as the first round of reviewing for JFP, provided the reviews meet the standards of the journal.  Authors of accepted papers will then be given the option to revise their papers for submission to JFP.  To assure that these appear in a timely fashion, and to give authors the chance to include feedback from the Symposium, the deadline for revision will shorty after the Symposium itself.  Revised papers will be reviewed by JFP, most likely by the original reviewers.
+JFP will accept the HS reviews as the first round of reviewing for JFP, provided the reviews meet the standards of the journal.  Authors of accepted papers will then be given the option to revise their papers for submission to JFP.  To assure that these appear in a timely fashion, and to give authors the chance to include feedback from the Symposium, the deadline for revision will be shortly after the Symposium itself.  Revised papers will be reviewed by JFP, most likely by the original reviewers.
 
 The final decision of the JFP editors is, of course, independent of the decision of the Haskell Symposium PC.
 

--- a/proposals/0000-haskell-symposium-changes.md
+++ b/proposals/0000-haskell-symposium-changes.md
@@ -1,0 +1,51 @@
+# RFC: Reinvigorating the Haskell Symposium
+
+## Abstract
+
+In recent years, submissions to the Haskell Symposium have dropped sharply, making it increasingly difficult to compile a compelling event.  The Haskell Symposium steering committee has developed two independent proposals to address this.  First, we propose to accept presentations of work-in-progress.  Second, we propose that full papers at the Haskell Symposium should be submitted to JFP for publication, rather than being published in the proceedings of the symposium.  We invite feedback from the community on how these changes would effect their decisions to submit work to the Haskell Symposium.
+
+## Motivation
+
+Over the past several years, submissions to the Haskell Symposium have dropped sharply—from 34 in 2017, just two off the all-time high, to just 15 last year.  While submissions to ICFP itself have dropped over the same window, submissions to Haskell have dropped more steeply.  This makes it increasingly difficult to compile a compelling and intellectually rigorous program.
+
+One contributing explanation for this decline is the increasing role bibliometrics plays in evaluating career academics.  Despite the quality of reviewing at the Haskell Symposium, it is listed as a C tier venue—"other ranked conference venues that meet basic standards for peer reviewed venues"—in the CoRE rankings, and is not included in the [csrankings.org](https://csrankings.org) rankings of computer science departments.
+
+In response, the Steering Committee is proposing two changes to the Haskell Symposium.  They are each, independently, intended to restore the Symposium's role as a center of vibrant discussion in research on pure functional programming.
+
+## Proposal 1: Talk Proposals
+
+The steering committee proposes that the Haskell Symposium invite a new category of submissions, **talk proposals**. Including talk proposals invites discussion of high-quality work at the Haskell Symposium, while recognizing the pressures that lead that work to be preferentially published at a future SIGPLAN conference.
+
+Talk proposals will be described in the call for papers by:
+
+> Talk proposals need not be full-length, and should report work in progress relevant to Haskell language design, theory, tools, or applications.  Extended abstracts will be evaluated by the PC for novelty and relevance to the Haskell community, but are not expected to include finished results.  
+
+Talk proposals will not be distributed to attendees, but authors of talk proposals may provide links to materials to be included on the program.
+
+## Proposal 2: JFP Submission of Accepted Papers
+
+The steering committee proposes to cease publishing the proceedings of the Haskell Symposium as an archival ACM publication.   Instead, **authors of accepted research papers and functional pearls will have the option of submitting their papers to an expedited review process for inclusion in the Journal of Functional Programming**. This provides a better-regarded publication venue for work presented at the Haskell Symposium, encouraging submission of high quality work to the Symposium.
+
+### For authors
+
+Under this proposal, authors will still submit papers to the Haskell Symposium, and receive reviews from the PC, on the usual schedule.    
+
+Authors of accepted papers will present their papers at the Symposium.  
+
+JFP will accept the HS reviews as the first round of reviewing for JFP, provided the reviews meet the standards of the journal.  Authors of accepted papers will then be given the option to revise their papers for submission to the Journal of Functional Programming.  To assure that these appear in a timely fashion, the deadline for revision will likely be around the time of the Symposium itself.  Revised paper will be reviewed by JFP, most likely by the original reviewers.
+
+The final decision of the JFP editors is, of course, independent of the decision of the Haskell Symposium PC.
+
+### For PC members
+
+Under this proposal, reviews of (accepted) papers should meet JFP's review standards.  Haskell Symposium reviewers should also be prepared to review paper revisions for JFP.
+
+### For the community
+
+A consequence of moving away from an archival proceedings is that ACM SIGPLAN may ask us to change the title of the meeting to something more like "Haskell Workshop", to line up with other language workshops held around ICFP.
+
+## Stakeholders
+
+The primary stakeholders are future authors and participants in the Haskell Symposium.    
+
+In particular, we invite feedback on whether the JFP submission process would make authors more (or less) likely to consider the Haskell Symposium as a venue for presenting work in the future.


### PR DESCRIPTION
This is an RFC regarding planned changes to the Haskell Symposium: inviting new types of contribution, and submitting accepted papers to JFP rather than having a proceedings.

[Rendered.](https://github.com/haskellfoundation/tech-proposals/blob/4a422513c3523a7eb36d3a7be47c42a427b64f91/proposals/0000-haskell-symposium-changes.md)
